### PR TITLE
Remove CodeMirror.defineInitHook

### DIFF
--- a/docs/agda.js
+++ b/docs/agda.js
@@ -514,34 +514,6 @@
     return { list: list, from: from, to: to };
   };
 
-  // TODO Is it possible to disable running this hook in other modes?
-  CodeMirror.defineInitHook(function(cm) {
-    cm.addKeyMap({
-      "\\": function(cm) {
-        cm.replaceSelection("\\");
-        cm.execCommand("autocomplete");
-      },
-    });
-
-    const hintOptions = cm.getOption("hintOptions") || {};
-    hintOptions.extraKeys = {
-      // Complete with selected and insert space.
-      Space: function(cm) {
-        const cA = cm.state.completionActive;
-        if (cA) {
-          cA.widget.pick();
-          cm.replaceSelection(" ");
-        }
-      },
-    };
-    // Use custom `closeCharacters` to allow text with ()[]{};:>,
-    // Note that this isn't documented.
-    hintOptions.closeCharacters = /[\s]/;
-    // Disable auto completing even if there's only one choice.
-    hintOptions.completeSingle = false;
-    cm.setOption("hintOptions", hintOptions);
-  });
-
   CodeMirror.registerGlobalHelper(
     "hint",
     "agda-input",

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,6 +45,7 @@ refl ⇆ refl = refl
   <select id="mode-select" data-option-key="mode">
     <option value="agda">Agda</option>
     <option value="haskell">Haskell</option>
+    <option value="python">Python</option>
   </select>
 
   <label for="keymap-select">KeyMap:</label>
@@ -60,20 +61,58 @@ refl ⇆ refl = refl
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/addon/mode/simple.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/addon/hint/show-hint.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/mode/haskell/haskell.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/mode/python/python.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/keymap/vim.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/keymap/emacs.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/keymap/sublime.min.js"></script>
 <script src="agda.js"></script>
 <script>
+  const autocompleteKeyMap = {
+    "\\": function(cm) {
+      cm.replaceSelection("\\");
+      cm.execCommand("autocomplete");
+    },
+  };
+  const hintOptions = {
+    extraKeys: {
+      // Complete with selected and insert space.
+      Space: function(cm) {
+        const cA = cm.state.completionActive;
+        if (cA) {
+          cA.widget.pick();
+          cm.replaceSelection(" ");
+        }
+      },
+    },
+    // Use custom `closeCharacters` to allow text with ()[]{};:>,
+    // Note that this isn't documented.
+    closeCharacters: /[\s]/,
+    // Disable auto completing even if there's only one choice.
+    completeSingle: false,
+  };
+
+  // hook to only enable completion in agda mode
+  function setOption(editor, key, value) {
+    if (key === "mode") {
+      if (value === "agda") {
+        editor.addKeyMap(autocompleteKeyMap);
+        editor.setOption("hintOptions", hintOptions);
+      } else {
+        editor.removeKeyMap(autocompleteKeyMap);
+        editor.setOption("hintOptions", undefined);
+      }
+    }
+    editor.setOption(key, value);
+  }
+
   const editor = CodeMirror.fromTextArea(document.getElementById("code"), {
-    mode: "agda",
     lineNumbers: true,
     theme: "base16-dark",
     keyMap: "default",
   });
-
+  setOption(editor, "mode", "agda");
   document.getElementById("selects").addEventListener("change", function(e) {
-    editor.setOption(e.target.dataset.optionKey, e.target.value);
+    setOption(editor, e.target.dataset.optionKey, e.target.value);
     e.stopPropagation();
   });
 </script>

--- a/src/agda-input.js
+++ b/src/agda-input.js
@@ -15,34 +15,6 @@ const createHint = table => (editor, _options) => {
   return { list: list, from: from, to: to };
 };
 
-// TODO Is it possible to disable running this hook in other modes?
-CodeMirror.defineInitHook(function(cm) {
-  cm.addKeyMap({
-    "\\": function(cm) {
-      cm.replaceSelection("\\");
-      cm.execCommand("autocomplete");
-    },
-  });
-
-  const hintOptions = cm.getOption("hintOptions") || {};
-  hintOptions.extraKeys = {
-    // Complete with selected and insert space.
-    Space: function(cm) {
-      const cA = cm.state.completionActive;
-      if (cA) {
-        cA.widget.pick();
-        cm.replaceSelection(" ");
-      }
-    },
-  };
-  // Use custom `closeCharacters` to allow text with ()[]{};:>,
-  // Note that this isn't documented.
-  hintOptions.closeCharacters = /[\s]/;
-  // Disable auto completing even if there's only one choice.
-  hintOptions.completeSingle = false;
-  cm.setOption("hintOptions", hintOptions);
-});
-
 CodeMirror.registerGlobalHelper(
   "hint",
   "agda-input",


### PR DESCRIPTION
Removing to avoid interfering with other modes. Now the registration needs to be handled by the users of this package.
Example of only enabling in one mode is provided in the demo.